### PR TITLE
devcontainer: Add dotfiles fallback and nested container support

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -7,8 +7,10 @@ devaipod is configured via `~/.config/devaipod.toml` and per-project `devcontain
 Create `~/.config/devaipod.toml`:
 
 ```toml
-# Default image for repositories without devcontainer.json (optional)
-default-image = "ghcr.io/bootc-dev/devenv-debian"
+# Dotfiles repository - its devcontainer.json is used as a fallback
+# when a project has no devcontainer.json of its own
+[dotfiles]
+url = "https://github.com/you/homegit"
 
 # Global environment variables for all containers
 [env]
@@ -45,26 +47,48 @@ port = 8765
 
 ## Using Without devcontainer.json
 
-Not all repositories include a `devcontainer.json`. There are two ways to use devaipod with these repos:
+Not all repositories include a `devcontainer.json`. The recommended approach is to
+put a default `devcontainer.json` in your dotfiles repository. When a project has no
+devcontainer.json, devaipod automatically checks your dotfiles repo for one.
 
-**Option 1: Set a default image globally** (recommended)
+**Dotfiles devcontainer.json** (recommended)
 
-Add to `~/.config/devaipod.toml`:
+Add a `.devcontainer/devcontainer.json` to your dotfiles repo (configured via
+`[dotfiles]` in devaipod.toml). This is the natural place for user-level defaults
+like your preferred image, nested container support, and lifecycle commands:
 
-```toml
-default-image = "ghcr.io/bootc-dev/devenv-debian"
+```json
+{
+  "image": "ghcr.io/bootc-dev/devenv-debian",
+  "customizations": {
+    "devaipod": { "nestedContainers": true }
+  },
+  "runArgs": ["--privileged"],
+  "postCreateCommand": {
+    "devenv-init": "sudo /usr/local/bin/devenv-init.sh"
+  }
+}
 ```
 
-This image will be used automatically for any repository that lacks a devcontainer.json.
+The `runArgs` with `--privileged` keeps compatibility with the stock devcontainer CLI,
+while `nestedContainers: true` tells devaipod to use a tighter set of capabilities
+instead.
 
-**Option 2: Specify an image per-invocation**
+To force the dotfiles devcontainer.json even when a project has its own, use
+`--use-default-devcontainer` (or the checkbox in the web UI).
 
-```bash
-devaipod up https://github.com/org/repo --image ghcr.io/bootc-dev/devenv-debian
-devaipod run https://github.com/org/repo --image ghcr.io/bootc-dev/devenv-debian -c 'fix typos'
-```
+The resolution order is:
 
-The `--image` flag takes precedence over both `default-image` and any devcontainer.json.
+1. `--devcontainer-json` inline override
+2. Project's devcontainer.json (skipped with `--use-default-devcontainer`)
+3. Dotfiles repo's devcontainer.json
+4. `--image` flag with default settings
+5. `default-image` from config with default settings
+
+**Other options**
+
+You can also specify `--image` per-invocation or set `default-image` in the config,
+but these only set the image without any lifecycle commands or customizations.
 
 ## Per-Project Configuration
 

--- a/opencode-ui/packages/app/src/context/devaipod.tsx
+++ b/opencode-ui/packages/app/src/context/devaipod.tsx
@@ -46,6 +46,7 @@ export interface LaunchWorkspaceParams {
   service_gator_image?: string
   service_gator_ro?: boolean
   devcontainer_json?: string
+  use_default_devcontainer?: boolean
 }
 
 /** GitHub repo permission flags from the gator config */

--- a/opencode-ui/packages/app/src/pages/pods.tsx
+++ b/opencode-ui/packages/app/src/pages/pods.tsx
@@ -217,6 +217,7 @@ function LaunchForm(props: { onClose: () => void }) {
   const [gatorImage, setGatorImage] = createSignal("")
   const [readOnly, setReadOnly] = createSignal(true)
   const [devcontainerJson, setDevcontainerJson] = createSignal("")
+  const [useDefaultDevcontainer, setUseDefaultDevcontainer] = createSignal(false)
   const [submitting, setSubmitting] = createSignal(false)
   const [error, setError] = createSignal("")
 
@@ -258,6 +259,7 @@ function LaunchForm(props: { onClose: () => void }) {
       if (readOnly()) params.service_gator_ro = true
       const dcj = devcontainerJson().trim()
       if (dcj) params.devcontainer_json = dcj
+      if (useDefaultDevcontainer()) params.use_default_devcontainer = true
 
       await ctx.launchWorkspace(params)
       props.onClose()
@@ -307,6 +309,13 @@ function LaunchForm(props: { onClose: () => void }) {
                 value={imageOverride()}
                 onChange={setImageOverride}
               />
+
+              <Checkbox
+                checked={useDefaultDevcontainer()}
+                onChange={setUseDefaultDevcontainer}
+              >
+                Use default devcontainer (from dotfiles repo instead of project's)
+              </Checkbox>
 
               <div>
                 <label class="text-12-regular text-text-weak block mb-1">Service-gator scopes</label>

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,16 @@ pub struct Config {
     /// Additional MCP servers to attach to agent pods
     #[serde(default)]
     pub mcp: McpServersConfig,
+
+    /// Enable nested container support even without a devcontainer.json.
+    /// When true, containers get the minimal privileges needed for
+    /// nested podman (SYS_ADMIN, NET_ADMIN, unmask=/proc/*, etc.)
+    /// without full --privileged.
+    ///
+    /// This is useful with `default-image` for repos that don't have
+    /// a devcontainer.json but still need nested container support.
+    #[serde(default, rename = "container-nesting")]
+    pub container_nesting: bool,
 }
 
 /// Configuration for binding paths from host home to container home
@@ -995,6 +1005,16 @@ mod tests {
         assert_eq!(config.secrets.len(), 0);
         assert!(config.dotfiles.is_none());
         assert!(config.default_image.is_none());
+        assert!(!config.container_nesting);
+    }
+
+    #[test]
+    fn test_parse_container_nesting() {
+        let toml = r#"
+container-nesting = true
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!(config.container_nesting);
     }
 
     #[test]

--- a/src/devcontainer.rs
+++ b/src/devcontainer.rs
@@ -122,6 +122,16 @@ pub struct DevaipodCustomizations {
     /// This is an alternative to using DEVAIPOD_AGENT_* prefix.
     #[serde(default)]
     pub env_allowlist: Vec<String>,
+
+    /// When true, apply minimal privileges for nested container support
+    /// (unmask=/proc/*, SYS_ADMIN, NET_ADMIN, seccomp=unconfined, label=disable,
+    /// /dev/net/tun) instead of full --privileged.
+    ///
+    /// This allows devcontainer.json to use "privileged": true for compatibility
+    /// with stock devcontainer CLI tooling (Docker/Podman), while devaipod uses
+    /// more targeted security settings.
+    #[serde(default)]
+    pub nested_containers: bool,
 }
 
 fn default_workspace_folder() -> String {
@@ -314,6 +324,15 @@ impl DevcontainerConfig {
     /// Check if this configuration has any features defined
     pub fn has_features(&self) -> bool {
         !self.features.is_empty()
+    }
+
+    /// Check if devaipod nested containers mode is enabled
+    pub fn has_nested_containers(&self) -> bool {
+        self.customizations
+            .as_ref()
+            .and_then(|c| c.devaipod.as_ref())
+            .map(|d| d.nested_containers)
+            .unwrap_or(false)
     }
 
     /// Check if --privileged is in runArgs
@@ -887,5 +906,41 @@ mod tests {
     fn test_passthrough_run_args_empty() {
         let config = DevcontainerConfig::default();
         assert!(config.passthrough_run_args().is_empty());
+    }
+
+    #[test]
+    fn test_parse_nested_containers() {
+        let json = r#"{
+            "image": "foo",
+            "privileged": true,
+            "customizations": {
+                "devaipod": {
+                    "nestedContainers": true
+                }
+            }
+        }"#;
+        let config: DevcontainerConfig = serde_json::from_str(json).unwrap();
+        assert!(config.has_nested_containers());
+        assert!(config.privileged); // raw field is still true
+    }
+
+    #[test]
+    fn test_nested_containers_default_false() {
+        let json = r#"{
+            "image": "foo",
+            "customizations": {
+                "devaipod": {
+                    "envAllowlist": ["FOO"]
+                }
+            }
+        }"#;
+        let config: DevcontainerConfig = serde_json::from_str(json).unwrap();
+        assert!(!config.has_nested_containers());
+    }
+
+    #[test]
+    fn test_nested_containers_no_customizations() {
+        let config = DevcontainerConfig::default();
+        assert!(!config.has_nested_containers());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -388,6 +388,14 @@ struct UpOptions {
     /// Example: --devcontainer-json '{"image": "debian", "capAdd": ["SYS_ADMIN"]}'
     #[arg(long, value_name = "JSON")]
     devcontainer_json: Option<String>,
+    /// Use the devcontainer.json from your dotfiles repo instead of the project's.
+    ///
+    /// When set, any devcontainer.json in the target repository is ignored and the
+    /// one from the dotfiles repository (configured in [dotfiles] in devaipod.toml)
+    /// is used instead. This is useful for ensuring your personal environment
+    /// settings (nested containers, lifecycle commands, etc.) always apply.
+    #[arg(long)]
+    use_default_devcontainer: bool,
 }
 
 /// Internal options for workspace creation (like `podman create` vs `podman run`)
@@ -415,6 +423,8 @@ struct CreateOptions {
     mcp_servers: Vec<String>,
     /// Inline devcontainer JSON that replaces the repo's devcontainer.json
     devcontainer_json: Option<String>,
+    /// Use the devcontainer.json from dotfiles instead of the project's
+    use_default_devcontainer: bool,
 }
 
 impl CreateOptions {
@@ -431,6 +441,7 @@ impl CreateOptions {
             service_gator_ro: false,
             mcp_servers: opts.mcp_servers.clone(),
             devcontainer_json: opts.devcontainer_json.clone(),
+            use_default_devcontainer: opts.use_default_devcontainer,
         }
     }
 }
@@ -740,6 +751,9 @@ enum HostCommand {
         /// Example: --devcontainer-json '{"image": "debian", "capAdd": ["SYS_ADMIN"]}'
         #[arg(long, value_name = "JSON")]
         devcontainer_json: Option<String>,
+        /// Use the devcontainer.json from your dotfiles repo instead of the project's
+        #[arg(long)]
+        use_default_devcontainer: bool,
     },
     /// Generate shell completions
     ///
@@ -1266,6 +1280,7 @@ async fn run_host(cli: HostCli) -> Result<()> {
             service_gator_ro,
             mcp_servers,
             devcontainer_json,
+            use_default_devcontainer,
         } => {
             let source = resolve_source(source.as_deref(), &config)?;
 
@@ -1340,6 +1355,7 @@ async fn run_host(cli: HostCli) -> Result<()> {
                 service_gator_ro,
                 &mcp_servers,
                 devcontainer_json.as_deref(),
+                use_default_devcontainer,
             )
             .await?;
 
@@ -1639,6 +1655,139 @@ async fn create_workspace(
     Ok(result)
 }
 
+/// Resolve the devcontainer configuration for a project.
+///
+/// Searches in priority order:
+/// 1. Inline JSON override (--devcontainer-json)
+/// 2. devcontainer.json in the project source
+/// 3. devcontainer.json from the dotfiles repository (cloned to a temp dir)
+/// 4. --image override with default DevcontainerConfig
+/// 5. default-image from config with default DevcontainerConfig
+///
+/// The dotfiles fallback (step 3) allows users to define a default devcontainer
+/// configuration in their dotfiles repo that applies to projects without their
+/// own devcontainer.json. This is the natural place for user-level defaults
+/// like nested container support, default extensions, or lifecycle commands.
+async fn resolve_devcontainer_config(
+    config: &config::Config,
+    project_path: &Path,
+    opts: &CreateOptions,
+    source_description: &str,
+) -> Result<(devcontainer::DevcontainerConfig, Option<String>)> {
+    // 1. Inline JSON override takes highest priority
+    if let Some(ref json) = opts.devcontainer_json {
+        tracing::info!("Using inline devcontainer JSON override");
+        return Ok((
+            devcontainer::parse_jsonc(json).context("Failed to parse --devcontainer-json")?,
+            opts.image.clone(),
+        ));
+    }
+
+    // 2. Check the project source (unless user requested the dotfiles devcontainer)
+    if !opts.use_default_devcontainer {
+        if let Some(ref path) = devcontainer::try_find_devcontainer_json(project_path) {
+            return Ok((devcontainer::load(path)?, opts.image.clone()));
+        }
+    }
+
+    // 3. Check the dotfiles repository for a devcontainer.json
+    if let Some(ref dotfiles) = config.dotfiles {
+        let gh_token = git::get_github_token_with_secret(config);
+        match clone_dotfiles_for_devcontainer(&dotfiles.url, gh_token.as_deref()).await {
+            Ok(Some((dotfiles_config, _temp_dir))) => {
+                tracing::info!("Using devcontainer.json from dotfiles ({})", dotfiles.url);
+                // If the dotfiles devcontainer specifies an image, use it;
+                // otherwise fall through to image override / default-image.
+                let effective_image = opts.image.clone().or_else(|| {
+                    dotfiles_config
+                        .image
+                        .clone()
+                        .or_else(|| config.default_image.clone())
+                });
+                return Ok((dotfiles_config, effective_image));
+            }
+            Ok(None) => {
+                tracing::debug!("No devcontainer.json found in dotfiles repo");
+            }
+            Err(e) => {
+                tracing::debug!("Failed to check dotfiles for devcontainer.json: {:#}", e);
+            }
+        }
+    }
+
+    // 4. Image override
+    if opts.image.is_some() {
+        tracing::info!(
+            "No devcontainer.json found in {}, using defaults with --image override",
+            source_description
+        );
+        return Ok((
+            devcontainer::DevcontainerConfig::default(),
+            opts.image.clone(),
+        ));
+    }
+
+    // 5. Default image from config
+    if let Some(ref default_image) = config.default_image {
+        tracing::info!(
+            "No devcontainer.json found in {}, using default-image from config: {}",
+            source_description,
+            default_image
+        );
+        return Ok((
+            devcontainer::DevcontainerConfig::default(),
+            Some(default_image.clone()),
+        ));
+    }
+
+    bail!(
+        "No devcontainer.json found in {}.\n\
+         Either add a devcontainer.json, use --image, or set default-image in config.",
+        source_description
+    );
+}
+
+/// Clone the dotfiles repo to a temp directory and look for a devcontainer.json.
+///
+/// Returns `Ok(Some((config, temp_dir)))` if found, `Ok(None)` if the dotfiles
+/// repo has no devcontainer.json. The `TempDir` is returned so the caller keeps
+/// it alive for as long as the config may reference relative paths (e.g. Dockerfile builds).
+async fn clone_dotfiles_for_devcontainer(
+    dotfiles_url: &str,
+    gh_token: Option<&str>,
+) -> Result<Option<(devcontainer::DevcontainerConfig, tempfile::TempDir)>> {
+    let temp_dir = tempfile::tempdir().context("Failed to create temp directory for dotfiles")?;
+    let clone_url = git::authenticated_clone_url(dotfiles_url, gh_token);
+
+    let output = tokio::process::Command::new("git")
+        .args([
+            "clone",
+            "--depth",
+            "1",
+            "--filter=blob:none",
+            &clone_url,
+            temp_dir.path().to_str().unwrap(),
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .await
+        .context("Failed to clone dotfiles repo")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("Failed to clone dotfiles repo: {}", stderr.trim());
+    }
+
+    match devcontainer::try_find_devcontainer_json(temp_dir.path()) {
+        Some(path) => {
+            let config = devcontainer::load(&path)?;
+            Ok(Some((config, temp_dir)))
+        }
+        None => Ok(None),
+    }
+}
+
 /// Create a workspace from a local git repository
 async fn create_workspace_from_local(
     config: &config::Config,
@@ -1712,40 +1861,13 @@ async fn create_workspace_from_local(
         }
     }
 
-    // Load devcontainer config: inline override > repo file > --image > default-image
-    let (devcontainer_config, effective_image) = if let Some(ref json) = opts.devcontainer_json {
-        tracing::info!("Using inline devcontainer JSON override");
-        (
-            devcontainer::parse_jsonc(json).context("Failed to parse --devcontainer-json")?,
-            opts.image.clone(),
-        )
-    } else {
-        let devcontainer_json_path = devcontainer::try_find_devcontainer_json(project_path);
-        if let Some(ref path) = devcontainer_json_path {
-            (devcontainer::load(path)?, opts.image.clone())
-        } else if opts.image.is_some() {
-            tracing::info!("No devcontainer.json found, using defaults with --image override");
-            (
-                devcontainer::DevcontainerConfig::default(),
-                opts.image.clone(),
-            )
-        } else if config.default_image.is_some() {
-            tracing::info!(
-                "No devcontainer.json found, using default-image from config: {}",
-                config.default_image.as_ref().unwrap()
-            );
-            (
-                devcontainer::DevcontainerConfig::default(),
-                config.default_image.clone(),
-            )
-        } else {
-            bail!(
-                "No devcontainer.json found in {}.\n\
-                 Either add a devcontainer.json, use --image, or set default-image in config.",
-                project_path.display()
-            );
-        }
-    };
+    let (devcontainer_config, effective_image) = resolve_devcontainer_config(
+        config,
+        project_path,
+        opts,
+        &project_path.display().to_string(),
+    )
+    .await?;
 
     // Derive project/pod name from path
     let project_name = project_path
@@ -1930,42 +2052,8 @@ async fn create_workspace_from_remote(
         "main".to_string() // Fallback
     };
 
-    // Load devcontainer config: inline override > repo file > --image > default-image
-    let (devcontainer_config, effective_image) = if let Some(ref json) = opts.devcontainer_json {
-        tracing::info!("Using inline devcontainer JSON override");
-        (
-            devcontainer::parse_jsonc(json).context("Failed to parse --devcontainer-json")?,
-            opts.image.clone(),
-        )
-    } else {
-        let devcontainer_json_path = devcontainer::try_find_devcontainer_json(temp_path);
-        if let Some(ref path) = devcontainer_json_path {
-            (devcontainer::load(path)?, opts.image.clone())
-        } else if opts.image.is_some() {
-            tracing::info!(
-                "No devcontainer.json found in repository, using defaults with --image override"
-            );
-            (
-                devcontainer::DevcontainerConfig::default(),
-                opts.image.clone(),
-            )
-        } else if config.default_image.is_some() {
-            tracing::info!(
-                "No devcontainer.json found in repository, using default-image from config: {}",
-                config.default_image.as_ref().unwrap()
-            );
-            (
-                devcontainer::DevcontainerConfig::default(),
-                config.default_image.clone(),
-            )
-        } else {
-            bail!(
-                "No devcontainer.json found in {}.\n\
-                 Either add a devcontainer.json to the repository, use --image, or set default-image in config.",
-                remote_url
-            );
-        }
-    };
+    let (devcontainer_config, effective_image) =
+        resolve_devcontainer_config(config, temp_path, opts, remote_url).await?;
 
     // Use explicit name if provided, otherwise generate a unique name
     let pod_name = if let Some(ref name) = opts.name {
@@ -2147,41 +2235,9 @@ async fn create_workspace_from_pr(
         bail!("Failed to clone PR head repository: {}", stderr);
     }
 
-    // Load devcontainer config: inline override > repo file > --image > default-image
-    let (devcontainer_config, effective_image) = if let Some(ref json) = opts.devcontainer_json {
-        tracing::info!("Using inline devcontainer JSON override");
-        (
-            devcontainer::parse_jsonc(json).context("Failed to parse --devcontainer-json")?,
-            opts.image.clone(),
-        )
-    } else {
-        let devcontainer_json_path = devcontainer::try_find_devcontainer_json(temp_path);
-        if let Some(ref path) = devcontainer_json_path {
-            (devcontainer::load(path)?, opts.image.clone())
-        } else if opts.image.is_some() {
-            tracing::info!(
-                "No devcontainer.json found in PR, using defaults with --image override"
-            );
-            (
-                devcontainer::DevcontainerConfig::default(),
-                opts.image.clone(),
-            )
-        } else if config.default_image.is_some() {
-            tracing::info!(
-                "No devcontainer.json found in PR, using default-image from config: {}",
-                config.default_image.as_ref().unwrap()
-            );
-            (
-                devcontainer::DevcontainerConfig::default(),
-                config.default_image.clone(),
-            )
-        } else {
-            bail!(
-                "No devcontainer.json found in PR.\n\
-                 Either add a devcontainer.json to the PR, use --image, or set default-image in config."
-            );
-        }
-    };
+    let pr_description = format!("{}#{}", pr_ref.repo, pr_ref.number);
+    let (devcontainer_config, effective_image) =
+        resolve_devcontainer_config(config, temp_path, opts, &pr_description).await?;
 
     // Use explicit name if provided, otherwise generate a unique name
     let pod_name = if let Some(ref name) = opts.name {
@@ -2352,6 +2408,7 @@ async fn cmd_run(
     service_gator_ro: bool,
     mcp_servers: &[String],
     devcontainer_json: Option<&str>,
+    use_default_devcontainer: bool,
 ) -> Result<String> {
     // Build CreateOptions with mode=Run
     let create_opts = CreateOptions {
@@ -2364,6 +2421,7 @@ async fn cmd_run(
         service_gator_ro,
         mcp_servers: mcp_servers.to_vec(),
         devcontainer_json: devcontainer_json.map(|s| s.to_string()),
+        use_default_devcontainer,
     };
 
     // Create the workspace - no SSH by default (async execution)
@@ -3081,9 +3139,10 @@ async fn create_advisor_pod(config: &config::Config, task: Option<&str>) -> Resu
         Some("advisor"), // Becomes devaipod-advisor via normalize_pod_name
         &[],             // service-gator scopes from config
         None,
-        true, // read-only service-gator
-        &[],  // no CLI mcp_servers — entry is already in the config
-        None, // no devcontainer override
+        true,  // read-only service-gator
+        &[],   // no CLI mcp_servers — entry is already in the config
+        None,  // no devcontainer override
+        false, // don't override project devcontainer
     )
     .await?;
 
@@ -4377,19 +4436,30 @@ async fn cmd_rebuild(
         bail!("Failed to clone repository: {}", stderr);
     }
 
-    // Load devcontainer.json
+    // Load devcontainer.json: repo > dotfiles fallback > image override > default-image
     let devcontainer_json_path = devcontainer::try_find_devcontainer_json(temp_path);
-    let devcontainer_config = if let Some(ref path) = devcontainer_json_path {
-        devcontainer::load(path)?
+    let (devcontainer_config, dotfiles_image) = if let Some(ref path) = devcontainer_json_path {
+        (devcontainer::load(path)?, None)
+    } else if let Some(ref dotfiles) = config.dotfiles {
+        // Try dotfiles repo as fallback
+        let gh_token = git::get_github_token_with_secret(config);
+        match clone_dotfiles_for_devcontainer(&dotfiles.url, gh_token.as_deref()).await {
+            Ok(Some((dc_config, _temp_dir))) => {
+                tracing::info!("Using devcontainer.json from dotfiles ({})", dotfiles.url);
+                let img = dc_config.image.clone();
+                (dc_config, img)
+            }
+            _ => (devcontainer::DevcontainerConfig::default(), None),
+        }
     } else if image_override.is_some() {
         tracing::info!("No devcontainer.json found, using defaults with image override");
-        devcontainer::DevcontainerConfig::default()
-    } else if config.default_image.is_some() {
+        (devcontainer::DevcontainerConfig::default(), None)
+    } else if let Some(ref default_image) = config.default_image {
         tracing::info!(
             "No devcontainer.json found, using default-image from config: {}",
-            config.default_image.as_ref().unwrap()
+            default_image
         );
-        devcontainer::DevcontainerConfig::default()
+        (devcontainer::DevcontainerConfig::default(), None)
     } else {
         bail!(
             "No devcontainer.json found in repository.\n\
@@ -4459,8 +4529,11 @@ async fn cmd_rebuild(
     // and contains the original task file, so it will be picked up on restart.
     tracing::info!("Recreating containers with new image...");
 
-    // Use image_override if provided, otherwise fall back to default_image from config
-    let effective_image_override = image_override.or(config.default_image.as_deref());
+    // Use image_override if provided, then dotfiles image, then default_image from config
+    let effective_image_override: Option<String> = image_override
+        .map(|s| s.to_string())
+        .or(dotfiles_image)
+        .or_else(|| config.default_image.clone());
 
     let devaipod_pod = pod::DevaipodPod::create(
         &podman,
@@ -4472,7 +4545,7 @@ async fn cmd_rebuild(
         &source,
         &extra_labels,
         None,
-        effective_image_override,
+        effective_image_override.as_deref(),
         None, // gator_image_override not yet supported for rebuild
         None, // task - agent home volume persists with original task
         config.orchestration.is_enabled(),

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -142,6 +142,27 @@ fn collect_config_devices(config: &DevcontainerConfig, devices: &mut Vec<String>
     }
 }
 
+/// Return the minimal security settings for nested container support.
+///
+/// Returns `(privileged, cap_add, security_opts)` with the targeted set of
+/// privileges needed for podman-in-podman without full `--privileged`.
+/// Also adds `/dev/net/tun` to `devices` if it exists on the host.
+fn nested_container_security(devices: &mut Vec<String>) -> (bool, Vec<String>, Vec<String>) {
+    let tun = "/dev/net/tun".to_string();
+    if Path::new(&tun).exists() && !devices.contains(&tun) {
+        devices.push(tun);
+    }
+    (
+        false,
+        vec!["SYS_ADMIN".to_string(), "NET_ADMIN".to_string()],
+        vec![
+            "unmask=/proc/*".to_string(),
+            "label=disable".to_string(),
+            "seccomp=unconfined".to_string(),
+        ],
+    )
+}
+
 /// Port for the opencode server in the agent container
 pub const OPENCODE_PORT: u16 = 4096;
 
@@ -2095,8 +2116,30 @@ fi
             tracing::debug!("Devices for workspace container: {:?}", devices);
         }
 
-        // Check if privileged mode is requested (either directly or via runArgs)
-        let privileged = config.privileged || config.has_privileged_run_arg();
+        // When nestedContainers is set, we ignore all security config from
+        // devcontainer.json (privileged, capAdd, securityOpt, runArgs) and apply
+        // our own known-good minimal set. This lets devcontainer.json use
+        // "privileged": true for compatibility with stock tooling while devaipod
+        // uses a tighter security profile.
+        let (privileged, cap_add, security_opts) =
+            if config.has_nested_containers() || global_config.container_nesting {
+                nested_container_security(&mut devices)
+            } else {
+                let privileged = config.privileged || config.has_privileged_run_arg();
+                let mut cap_add = config.cap_add.clone();
+                for cap in config.cap_add_args() {
+                    if !cap_add.contains(&cap) {
+                        cap_add.push(cap);
+                    }
+                }
+                let mut security_opts = config.security_opt.clone();
+                for opt in config.security_opt_args() {
+                    if !security_opts.contains(&opt) {
+                        security_opts.push(opt);
+                    }
+                }
+                (privileged, cap_add, security_opts)
+            };
 
         // Get secrets to mount with type=env - workspace also gets trusted secrets
         // (like GH_TOKEN) for authenticated git operations, gh CLI, etc.
@@ -2172,28 +2215,10 @@ exec sleep infinity
                 ),
             ]),
             drop_all_caps: false,
-            // Merge capabilities from both capAdd field and runArgs
-            cap_add: {
-                let mut caps = config.cap_add.clone();
-                for cap in config.cap_add_args() {
-                    if !caps.contains(&cap) {
-                        caps.push(cap);
-                    }
-                }
-                caps
-            },
+            cap_add,
             no_new_privileges: false,
             devices,
-            // Merge security options from both securityOpt field and runArgs
-            security_opts: {
-                let mut opts = config.security_opt.clone();
-                for opt in config.security_opt_args() {
-                    if !opts.contains(&opt) {
-                        opts.push(opt);
-                    }
-                }
-                opts
-            },
+            security_opts,
             privileged,
             // Mount volumes:
             // - workspace volume at /workspaces (main workspace clone)
@@ -2323,24 +2348,27 @@ exec sleep infinity
                 // Add devices from runArgs; only pass through if they exist on the host
                 collect_config_devices(config, &mut devices);
 
-                // Check if privileged mode is requested
-                let privileged = config.privileged || config.has_privileged_run_arg();
-
-                // Merge security options from both securityOpt field and runArgs
-                let mut security_opts = config.security_opt.clone();
-                for opt in config.security_opt_args() {
-                    if !security_opts.contains(&opt) {
-                        security_opts.push(opt);
-                    }
-                }
-
-                // Merge capabilities from both capAdd field and runArgs
-                let mut cap_add = config.cap_add.clone();
-                for cap in config.cap_add_args() {
-                    if !cap_add.contains(&cap) {
-                        cap_add.push(cap);
-                    }
-                }
+                // When nestedContainers is set, ignore all security config from
+                // devcontainer.json and apply our own minimal set.
+                let (privileged, cap_add, security_opts) =
+                    if config.has_nested_containers() || global_config.container_nesting {
+                        nested_container_security(&mut devices)
+                    } else {
+                        let privileged = config.privileged || config.has_privileged_run_arg();
+                        let mut security_opts = config.security_opt.clone();
+                        for opt in config.security_opt_args() {
+                            if !security_opts.contains(&opt) {
+                                security_opts.push(opt);
+                            }
+                        }
+                        let mut cap_add = config.cap_add.clone();
+                        for cap in config.cap_add_args() {
+                            if !cap_add.contains(&cap) {
+                                cap_add.push(cap);
+                            }
+                        }
+                        (privileged, cap_add, security_opts)
+                    };
 
                 let extra_create_args = config.passthrough_run_args();
 
@@ -2351,6 +2379,10 @@ exec sleep infinity
                     cap_add,
                     extra_create_args,
                 )
+            } else if global_config.container_nesting {
+                let mut devices = vec![];
+                let (privileged, cap_add, security_opts) = nested_container_security(&mut devices);
+                (devices, privileged, security_opts, cap_add, vec![])
             } else {
                 (vec![], false, vec![], vec![], vec![])
             };
@@ -2760,22 +2792,27 @@ exec opencode serve --port {opencode_port} --hostname 0.0.0.0"#,
 
                 collect_config_devices(config, &mut devices);
 
-                let privileged = config.privileged || config.has_privileged_run_arg();
-
-                let mut security_opts = config.security_opt.clone();
-                for opt in config.security_opt_args() {
-                    if !security_opts.contains(&opt) {
-                        security_opts.push(opt);
-                    }
-                }
-
-                // Merge capabilities from both capAdd field and runArgs
-                let mut cap_add = config.cap_add.clone();
-                for cap in config.cap_add_args() {
-                    if !cap_add.contains(&cap) {
-                        cap_add.push(cap);
-                    }
-                }
+                // When nestedContainers is set, ignore all security config from
+                // devcontainer.json and apply our own minimal set.
+                let (privileged, cap_add, security_opts) =
+                    if config.has_nested_containers() || global_config.container_nesting {
+                        nested_container_security(&mut devices)
+                    } else {
+                        let privileged = config.privileged || config.has_privileged_run_arg();
+                        let mut security_opts = config.security_opt.clone();
+                        for opt in config.security_opt_args() {
+                            if !security_opts.contains(&opt) {
+                                security_opts.push(opt);
+                            }
+                        }
+                        let mut cap_add = config.cap_add.clone();
+                        for cap in config.cap_add_args() {
+                            if !cap_add.contains(&cap) {
+                                cap_add.push(cap);
+                            }
+                        }
+                        (privileged, cap_add, security_opts)
+                    };
 
                 let extra_create_args = config.passthrough_run_args();
 
@@ -2786,6 +2823,10 @@ exec opencode serve --port {opencode_port} --hostname 0.0.0.0"#,
                     cap_add,
                     extra_create_args,
                 )
+            } else if global_config.container_nesting {
+                let mut devices = vec![];
+                let (privileged, cap_add, security_opts) = nested_container_security(&mut devices);
+                (devices, privileged, security_opts, cap_add, vec![])
             } else {
                 (vec![], false, vec![], vec![], vec![])
             };

--- a/src/web.rs
+++ b/src/web.rs
@@ -1071,6 +1071,9 @@ struct RunRequest {
     mcp_servers: Vec<String>,
     /// Inline devcontainer JSON that replaces the repo's devcontainer.json
     devcontainer_json: Option<String>,
+    /// Use the devcontainer.json from dotfiles instead of the project's
+    #[serde(default)]
+    use_default_devcontainer: bool,
 }
 
 /// Response for run endpoint
@@ -1164,6 +1167,10 @@ async fn run_workspace(
 
     if let Some(ref json) = req.devcontainer_json {
         cmd.args(["--devcontainer-json", json]);
+    }
+
+    if req.use_default_devcontainer {
+        cmd.arg("--use-default-devcontainer");
     }
 
     // Prevent stdin reads from blocking the server process


### PR DESCRIPTION
Add nestedContainers customization flag in devcontainer.json that applies minimal capabilities (SYS_ADMIN, NET_ADMIN, unmask=/proc/*, label=disable, seccomp=unconfined) instead of full --privileged. This lets devcontainer.json use "privileged": true for stock devcontainer CLI compatibility while devaipod uses a tighter security profile.

When a project has no devcontainer.json, devaipod now checks the dotfiles repository (configured via [dotfiles] in devaipod.toml) for one before falling back to --image or default-image. This lets users define environment defaults like nested container support, lifecycle commands, and image selection in their dotfiles rather than repeating --image on every invocation.

The resolution order is:
1. --devcontainer-json inline override
2. Project devcontainer.json (skipped with --use-default-devcontainer)
3. Dotfiles repo devcontainer.json
4. --image with default config
5. default-image from config

Also adds --use-default-devcontainer (CLI flag, API field, web UI checkbox) to force the dotfiles devcontainer.json even when the project has its own, and consolidates the four duplicated devcontainer lookup blocks into resolve_devcontainer_config().

Assisted-by: OpenCode (Claude claude-opus-4-6)