### PR TITLE
ui: Add workspace sort/group controls, compact view, and auto-title

### DIFF
--- a/opencode-ui/packages/app/src/context/devaipod.test.ts
+++ b/opencode-ui/packages/app/src/context/devaipod.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, test } from "bun:test"
+import {
+  sortByRepo,
+  sortByCreated,
+  sortPods,
+  groupPods,
+  frecencySortPods,
+  type PodInfo,
+  type AgentStatus,
+} from "./devaipod"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePod(overrides: Partial<PodInfo> & { Name: string }): PodInfo {
+  return {
+    Created: new Date().toISOString(),
+    Status: "running",
+    ...overrides,
+  } as PodInfo
+}
+
+/** Inline copy of autoTitleFromTask (not exported from pods.tsx). */
+function autoTitleFromTask(task: string): string {
+  const trimmed = task.trim().replace(/\s+/g, " ")
+  if (!trimmed) return ""
+  const firstLine = trimmed.split(/[.\n]/)[0].trim()
+  if (firstLine.length <= 50) return firstLine
+  const cut = firstLine.slice(0, 50)
+  const lastSpace = cut.lastIndexOf(" ")
+  return lastSpace > 20 ? cut.slice(0, lastSpace) : cut
+}
+
+/** No-op agent status lookup — everything returns undefined. */
+const noStatus = (_name: string): AgentStatus | undefined => undefined
+
+// ---------------------------------------------------------------------------
+// sortByRepo
+// ---------------------------------------------------------------------------
+
+describe("sortByRepo", () => {
+  test("advisor pod always sorts first", () => {
+    const pods = [
+      makePod({ Name: "alpha", Labels: { "io.devaipod.repo": "aaa" } }),
+      makePod({ Name: "devaipod-advisor" }),
+      makePod({ Name: "beta", Labels: { "io.devaipod.repo": "bbb" } }),
+    ]
+    const sorted = sortByRepo(pods)
+    expect(sorted[0].Name).toBe("devaipod-advisor")
+  })
+
+  test("sorts alphabetically by repo label", () => {
+    const pods = [
+      makePod({ Name: "p2", Labels: { "io.devaipod.repo": "zrepo" } }),
+      makePod({ Name: "p1", Labels: { "io.devaipod.repo": "arepo" } }),
+      makePod({ Name: "p3", Labels: { "io.devaipod.repo": "mrepo" } }),
+    ]
+    const sorted = sortByRepo(pods)
+    expect(sorted.map((p) => p.Labels!["io.devaipod.repo"])).toEqual([
+      "arepo",
+      "mrepo",
+      "zrepo",
+    ])
+  })
+
+  test("running pods sort before stopped within the same repo", () => {
+    const repo = "same-repo"
+    const pods = [
+      makePod({ Name: "stopped1", Status: "exited", Labels: { "io.devaipod.repo": repo } }),
+      makePod({ Name: "running1", Status: "running", Labels: { "io.devaipod.repo": repo } }),
+    ]
+    const sorted = sortByRepo(pods)
+    expect(sorted[0].Name).toBe("running1")
+    expect(sorted[1].Name).toBe("stopped1")
+  })
+
+  test("pods without a repo label sort together", () => {
+    const pods = [
+      makePod({ Name: "labeled", Labels: { "io.devaipod.repo": "myrepo" } }),
+      makePod({ Name: "unlabeled1" }),
+      makePod({ Name: "unlabeled2" }),
+    ]
+    const sorted = sortByRepo(pods)
+    // Empty string sorts before "myrepo", so unlabeled pods come first
+    const unlabeled = sorted.filter((p) => !p.Labels?.["io.devaipod.repo"])
+    expect(unlabeled).toHaveLength(2)
+    // They should be adjacent
+    const i1 = sorted.indexOf(unlabeled[0])
+    const i2 = sorted.indexOf(unlabeled[1])
+    expect(Math.abs(i1 - i2)).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sortByCreated
+// ---------------------------------------------------------------------------
+
+describe("sortByCreated", () => {
+  test("advisor pod always sorts first", () => {
+    const pods = [
+      makePod({ Name: "new-pod", Created: "2026-01-02T00:00:00Z" }),
+      makePod({ Name: "devaipod-advisor", Created: "2020-01-01T00:00:00Z" }),
+    ]
+    const sorted = sortByCreated(pods)
+    expect(sorted[0].Name).toBe("devaipod-advisor")
+  })
+
+  test("sorts by Created timestamp descending (newest first)", () => {
+    const pods = [
+      makePod({ Name: "oldest", Created: "2024-01-01T00:00:00Z" }),
+      makePod({ Name: "newest", Created: "2026-06-01T00:00:00Z" }),
+      makePod({ Name: "middle", Created: "2025-06-01T00:00:00Z" }),
+    ]
+    const sorted = sortByCreated(pods)
+    expect(sorted.map((p) => p.Name)).toEqual(["newest", "middle", "oldest"])
+  })
+
+  test("handles invalid Created gracefully", () => {
+    const pods = [
+      makePod({ Name: "valid", Created: "2025-06-01T00:00:00Z" }),
+      makePod({ Name: "invalid", Created: "not-a-date" }),
+    ]
+    const sorted = sortByCreated(pods)
+    // Invalid date gets timestamp 0 so valid comes first
+    expect(sorted[0].Name).toBe("valid")
+    expect(sorted[1].Name).toBe("invalid")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sortPods
+// ---------------------------------------------------------------------------
+
+describe("sortPods", () => {
+  const pods = [
+    makePod({ Name: "b", Created: "2025-01-01T00:00:00Z", Labels: { "io.devaipod.repo": "z" } }),
+    makePod({ Name: "a", Created: "2026-01-01T00:00:00Z", Labels: { "io.devaipod.repo": "a" } }),
+  ]
+
+  test("'repo' dispatches to sortByRepo", () => {
+    const result = sortPods(pods, "repo")
+    expect(result).toEqual(sortByRepo(pods))
+  })
+
+  test("'created' dispatches to sortByCreated", () => {
+    const result = sortPods(pods, "created")
+    expect(result).toEqual(sortByCreated(pods))
+  })
+
+  test("'activity' dispatches to frecencySortPods", () => {
+    const result = sortPods(pods, "activity")
+    expect(result).toEqual(frecencySortPods(pods))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// groupPods
+// ---------------------------------------------------------------------------
+
+describe("groupPods", () => {
+  describe("none", () => {
+    test("returns single group with empty label", () => {
+      const pods = [makePod({ Name: "a" }), makePod({ Name: "b" })]
+      const groups = groupPods(pods, "none", noStatus)
+      expect(groups).toHaveLength(1)
+      expect(groups[0].label).toBe("")
+      expect(groups[0].pods).toHaveLength(2)
+    })
+
+    test("returns empty array for empty input", () => {
+      expect(groupPods([], "none", noStatus)).toEqual([])
+    })
+  })
+
+  describe("repo", () => {
+    test("groups by io.devaipod.repo label", () => {
+      const pods = [
+        makePod({ Name: "p1", Labels: { "io.devaipod.repo": "repo-a" } }),
+        makePod({ Name: "p2", Labels: { "io.devaipod.repo": "repo-b" } }),
+        makePod({ Name: "p3", Labels: { "io.devaipod.repo": "repo-a" } }),
+      ]
+      const groups = groupPods(pods, "repo", noStatus)
+      expect(groups.map((g) => g.label)).toEqual(["repo-a", "repo-b"])
+      expect(groups[0].pods).toHaveLength(2)
+      expect(groups[1].pods).toHaveLength(1)
+    })
+
+    test("pods without label go to 'Other'", () => {
+      const pods = [
+        makePod({ Name: "labeled", Labels: { "io.devaipod.repo": "myrepo" } }),
+        makePod({ Name: "unlabeled" }),
+      ]
+      const groups = groupPods(pods, "repo", noStatus)
+      const other = groups.find((g) => g.label === "Other")
+      expect(other).toBeDefined()
+      expect(other!.pods[0].Name).toBe("unlabeled")
+    })
+  })
+
+  describe("status", () => {
+    const cases: Array<{
+      desc: string
+      podStatus: string
+      agentStatus: AgentStatus | undefined
+      expectedGroup: string
+    }> = [
+      {
+        desc: "running + Working -> Working",
+        podStatus: "running",
+        agentStatus: { activity: "Working" },
+        expectedGroup: "Working",
+      },
+      {
+        desc: "running + Idle -> Needs Attention",
+        podStatus: "running",
+        agentStatus: { activity: "Idle" },
+        expectedGroup: "Needs Attention",
+      },
+      {
+        desc: "running + Unknown -> Needs Attention",
+        podStatus: "running",
+        agentStatus: { activity: "Unknown" },
+        expectedGroup: "Needs Attention",
+      },
+      {
+        desc: "running + no agent status -> Needs Attention",
+        podStatus: "running",
+        agentStatus: undefined,
+        expectedGroup: "Needs Attention",
+      },
+      {
+        desc: "stopped -> Inactive",
+        podStatus: "exited",
+        agentStatus: { activity: "Stopped" },
+        expectedGroup: "Inactive",
+      },
+      {
+        desc: "running + done completion_status -> Inactive (edge case)",
+        podStatus: "running",
+        agentStatus: { activity: "Working", completion_status: "done" },
+        expectedGroup: "Inactive",
+      },
+    ]
+
+    for (const { desc, podStatus, agentStatus, expectedGroup } of cases) {
+      test(desc, () => {
+        const pod = makePod({ Name: "test-pod", Status: podStatus })
+        const lookup = (name: string) => (name === "test-pod" ? agentStatus : undefined)
+        const groups = groupPods([pod], "status", lookup)
+        expect(groups).toHaveLength(1)
+        expect(groups[0].label).toBe(expectedGroup)
+      })
+    }
+
+    test("multiple pods distribute across all groups", () => {
+      const pods = [
+        makePod({ Name: "worker", Status: "running" }),
+        makePod({ Name: "idle-one", Status: "running" }),
+        makePod({ Name: "stopped-one", Status: "exited" }),
+      ]
+      const lookup = (name: string): AgentStatus | undefined => {
+        if (name === "worker") return { activity: "Working" }
+        if (name === "idle-one") return { activity: "Idle" }
+        return undefined
+      }
+      const groups = groupPods(pods, "status", lookup)
+      expect(groups.map((g) => g.label)).toEqual(["Working", "Needs Attention", "Inactive"])
+    })
+  })
+
+  describe("time", () => {
+    test("returns groups in correct order", () => {
+      const now = Date.now()
+      const pods = [
+        makePod({ Name: "today", Created: new Date(now - 3600_000).toISOString() }),
+        makePod({ Name: "this-week", Created: new Date(now - 3 * 86_400_000).toISOString() }),
+        makePod({ Name: "this-month", Created: new Date(now - 14 * 86_400_000).toISOString() }),
+        makePod({ Name: "older", Created: new Date(now - 60 * 86_400_000).toISOString() }),
+      ]
+      const groups = groupPods(pods, "time", noStatus)
+      expect(groups.map((g) => g.label)).toEqual([
+        "Active Today",
+        "This Week",
+        "This Month",
+        "Older",
+      ])
+    })
+
+    test("omits empty time sections", () => {
+      const now = Date.now()
+      const pods = [
+        makePod({ Name: "today-only", Created: new Date(now - 1000).toISOString() }),
+      ]
+      const groups = groupPods(pods, "time", noStatus)
+      expect(groups).toHaveLength(1)
+      expect(groups[0].label).toBe("Active Today")
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// autoTitleFromTask
+// ---------------------------------------------------------------------------
+
+describe("autoTitleFromTask", () => {
+  const cases: Array<{ input: string; expected: string; desc: string }> = [
+    { desc: "empty string", input: "", expected: "" },
+    { desc: "whitespace only", input: "   \n  \t  ", expected: "" },
+    { desc: "short task returned as-is", input: "Fix the login bug", expected: "Fix the login bug" },
+    {
+      desc: "trims surrounding whitespace",
+      input: "  Fix the login bug  ",
+      expected: "Fix the login bug",
+    },
+    {
+      desc: "first sentence (before period) used if short",
+      input: "Fix the login bug. Also update the docs.",
+      expected: "Fix the login bug",
+    },
+    {
+      desc: "first line (before newline) used if short",
+      input: "Fix the login bug\nThis requires changing auth.ts",
+      expected: "Fix the login bug",
+    },
+    {
+      desc: "long task truncated at word boundary around 50 chars",
+      input:
+        "Implement the new authentication system with OAuth2 support and token refresh capabilities",
+      expected: "Implement the new authentication system with",
+    },
+    {
+      desc: "multiple whitespace collapsed",
+      input: "Fix   the    login     bug",
+      expected: "Fix the login bug",
+    },
+    {
+      desc: "exactly 50 chars returned as-is",
+      // 50 chars exactly: "aaaaa bbbbb ccccc ddddd eeeee fffff ggggg hhhhh ii"
+      input: "aaaaa bbbbb ccccc ddddd eeeee fffff ggggg hhhhh ii",
+      expected: "aaaaa bbbbb ccccc ddddd eeeee fffff ggggg hhhhh ii",
+    },
+    {
+      desc: "no word boundary after position 20 falls back to hard cut",
+      input: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+      expected: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwx",
+    },
+  ]
+
+  for (const { desc, input, expected } of cases) {
+    test(desc, () => {
+      expect(autoTitleFromTask(input)).toBe(expected)
+    })
+  }
+})

--- a/opencode-ui/packages/app/src/context/devaipod.tsx
+++ b/opencode-ui/packages/app/src/context/devaipod.tsx
@@ -72,6 +72,7 @@ export interface LaunchWorkspaceParams {
   devcontainer_json?: string
   use_default_devcontainer?: boolean
   no_auto_approve?: boolean
+  title?: string
 }
 
 /** GitHub repo permission flags from the gator config */
@@ -116,6 +117,16 @@ const PROPOSAL_POLL_MS = 10_000
 
 export type TimeSection = "Active Today" | "This Week" | "This Month" | "Older"
 
+export type SortBy = "activity" | "repo" | "created"
+export type GroupBy = "time" | "repo" | "status" | "none"
+export type Density = "comfortable" | "compact"
+
+export interface PodGroup {
+  label: string
+  pods: PodInfo[]
+}
+
+const ADVISOR_POD_NAME = "devaipod-advisor"
 const MS_DAY = 86_400_000
 const MS_WEEK = 7 * MS_DAY
 const MS_MONTH = 30 * MS_DAY
@@ -145,8 +156,8 @@ export function effectiveTimestamp(pod: PodInfo): number {
 export function frecencySortPods(pods: PodInfo[]): PodInfo[] {
   return [...pods].sort((a, b) => {
     // Advisor always first
-    const aAdvisor = a.Name === "devaipod-advisor" ? 1 : 0
-    const bAdvisor = b.Name === "devaipod-advisor" ? 1 : 0
+    const aAdvisor = a.Name === ADVISOR_POD_NAME ? 1 : 0
+    const bAdvisor = b.Name === ADVISOR_POD_NAME ? 1 : 0
     if (aAdvisor !== bAdvisor) return bAdvisor - aAdvisor
 
     // Running before stopped
@@ -157,6 +168,139 @@ export function frecencySortPods(pods: PodInfo[]): PodInfo[] {
     // Within same status group: sort by effective timestamp descending
     return effectiveTimestamp(b) - effectiveTimestamp(a)
   })
+}
+
+/**
+ * Sort pods alphabetically by repo label, then by effective timestamp descending
+ * within each repo. Running pods sort above stopped within the same repo.
+ * Advisor pod always first.
+ */
+export function sortByRepo(pods: PodInfo[]): PodInfo[] {
+  return [...pods].sort((a, b) => {
+    const aAdvisor = a.Name === ADVISOR_POD_NAME ? 1 : 0
+    const bAdvisor = b.Name === ADVISOR_POD_NAME ? 1 : 0
+    if (aAdvisor !== bAdvisor) return bAdvisor - aAdvisor
+
+    const aRepo = (a.Labels?.["io.devaipod.repo"] ?? "").toLowerCase()
+    const bRepo = (b.Labels?.["io.devaipod.repo"] ?? "").toLowerCase()
+    if (aRepo !== bRepo) return aRepo.localeCompare(bRepo)
+
+    const aRunning = (a.Status ?? "").toLowerCase() === "running" ? 1 : 0
+    const bRunning = (b.Status ?? "").toLowerCase() === "running" ? 1 : 0
+    if (aRunning !== bRunning) return bRunning - aRunning
+
+    return effectiveTimestamp(b) - effectiveTimestamp(a)
+  })
+}
+
+/**
+ * Sort pods by Created timestamp descending. Advisor pod always first.
+ */
+export function sortByCreated(pods: PodInfo[]): PodInfo[] {
+  return [...pods].sort((a, b) => {
+    const aAdvisor = a.Name === ADVISOR_POD_NAME ? 1 : 0
+    const bAdvisor = b.Name === ADVISOR_POD_NAME ? 1 : 0
+    if (aAdvisor !== bAdvisor) return bAdvisor - aAdvisor
+
+    // Use Created directly (ignoring LastActiveTs), falling back to 0 for invalid dates
+    const aTime = new Date(a.Created).getTime()
+    const bTime = new Date(b.Created).getTime()
+    return (Number.isNaN(bTime) ? 0 : bTime) - (Number.isNaN(aTime) ? 0 : aTime)
+  })
+}
+
+/** Dispatch to the correct sort function based on SortBy value. */
+export function sortPods(pods: PodInfo[], by: SortBy): PodInfo[] {
+  switch (by) {
+    case "activity": return frecencySortPods(pods)
+    case "repo": return sortByRepo(pods)
+    case "created": return sortByCreated(pods)
+  }
+}
+
+/**
+ * Group pods into labeled sections.
+ *
+ * @param pods - already sorted and filtered (group order preserves input sort order)
+ * @param by - grouping mode
+ * @param agentStatusLookup - function to get AgentStatus for a pod name
+ */
+export function groupPods(
+  pods: PodInfo[],
+  by: GroupBy,
+  agentStatusLookup: (name: string) => AgentStatus | undefined,
+): PodGroup[] {
+  if (by === "none") {
+    return pods.length > 0 ? [{ label: "", pods }] : []
+  }
+
+  if (by === "time") {
+    const now = Date.now()
+    const buckets = new Map<string, PodInfo[]>()
+    const order: TimeSection[] = ["Active Today", "This Week", "This Month", "Older"]
+    for (const pod of pods) {
+      const sec = timeSection(effectiveTimestamp(pod), now)
+      let list = buckets.get(sec)
+      if (!list) {
+        list = []
+        buckets.set(sec, list)
+      }
+      list.push(pod)
+    }
+    const groups: PodGroup[] = []
+    for (const sec of order) {
+      const list = buckets.get(sec)
+      if (list && list.length > 0) {
+        groups.push({ label: sec, pods: list })
+      }
+    }
+    return groups
+  }
+
+  if (by === "repo") {
+    const buckets = new Map<string, PodInfo[]>()
+    const order: string[] = []
+    for (const pod of pods) {
+      const repo = pod.Labels?.["io.devaipod.repo"] ?? ""
+      const key = repo || "Other"
+      let list = buckets.get(key)
+      if (!list) {
+        list = []
+        buckets.set(key, list)
+        order.push(key)
+      }
+      list.push(pod)
+    }
+    return order.map((key) => ({ label: key, pods: buckets.get(key)! }))
+  }
+
+  // by === "status"
+  // "Working" = autonomously active, no attention needed
+  // "Needs Attention" = running but idle/unknown, may need user input
+  // "Inactive" = stopped or marked done (even if still running)
+  const working: PodInfo[] = []
+  const needsAttention: PodInfo[] = []
+  const inactive: PodInfo[] = []
+
+  for (const pod of pods) {
+    const isRunning = (pod.Status ?? "").toLowerCase() === "running"
+    const status = agentStatusLookup(pod.Name)
+    const isDone = status?.completion_status === "done"
+
+    if (!isRunning || isDone) {
+      inactive.push(pod)
+    } else if (status?.activity === "Working") {
+      working.push(pod)
+    } else {
+      needsAttention.push(pod)
+    }
+  }
+
+  const groups: PodGroup[] = []
+  if (working.length > 0) groups.push({ label: "Working", pods: working })
+  if (needsAttention.length > 0) groups.push({ label: "Needs Attention", pods: needsAttention })
+  if (inactive.length > 0) groups.push({ label: "Inactive", pods: inactive })
+  return groups
 }
 
 // ---------------------------------------------------------------------------
@@ -458,7 +602,7 @@ export const { use: useDevaipod, provider: DevaipodProvider } = createSimpleCont
 
     // -- Derived state ------------------------------------------------------
 
-    const hasAdvisor = createMemo(() => store.pods.some((p) => p.Name === "devaipod-advisor"))
+    const hasAdvisor = createMemo(() => store.pods.some((p) => p.Name === ADVISOR_POD_NAME))
 
     const hasActiveLaunches = createMemo(
       () => Object.values(store.launches).some((l) => l.state === "launching"),

--- a/opencode-ui/packages/app/src/pages/pods.tsx
+++ b/opencode-ui/packages/app/src/pages/pods.tsx
@@ -10,6 +10,7 @@ import {
   Show,
   Switch,
 } from "solid-js"
+import { createStore } from "solid-js/store"
 import { Button } from "@opencode-ai/ui/button"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Icon } from "@opencode-ai/ui/icon"
@@ -28,10 +29,12 @@ import {
   type LaunchWorkspaceParams,
   type GatorScopeConfig,
   type GatorScopesResponse,
-  frecencySortPods,
   effectiveTimestamp,
-  timeSection,
-  type TimeSection,
+  type SortBy,
+  type GroupBy,
+  type Density,
+  sortPods,
+  groupPods,
 } from "@/context/devaipod"
 
 // ---------------------------------------------------------------------------
@@ -133,17 +136,251 @@ function podMatchesQuery(
 }
 
 // ---------------------------------------------------------------------------
-// Time section divider
+// View preferences (localStorage persistence)
 // ---------------------------------------------------------------------------
 
-const TIME_SECTION_ORDER: TimeSection[] = ["Active Today", "This Week", "This Month", "Older"]
+interface ViewPrefs {
+  sortBy: SortBy
+  groupBy: GroupBy
+  density: Density
+}
 
-function SectionDivider(props: { label: TimeSection }) {
+const VIEW_PREFS_KEY = "devaipod-view-prefs"
+
+function loadViewPrefs(): ViewPrefs {
+  try {
+    const raw = localStorage.getItem(VIEW_PREFS_KEY)
+    if (raw) {
+      const parsed = JSON.parse(raw)
+      return {
+        sortBy: (["activity", "repo", "created"] as SortBy[]).includes(parsed.sortBy) ? parsed.sortBy : "activity",
+        groupBy: (["time", "repo", "status", "none"] as GroupBy[]).includes(parsed.groupBy) ? parsed.groupBy : "time",
+        density: (["comfortable", "compact"] as Density[]).includes(parsed.density) ? parsed.density : "comfortable",
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return { sortBy: "activity", groupBy: "time", density: "comfortable" }
+}
+
+function saveViewPrefs(prefs: ViewPrefs) {
+  try {
+    localStorage.setItem(VIEW_PREFS_KEY, JSON.stringify(prefs))
+  } catch {
+    // ignore
+  }
+}
+
+// ---------------------------------------------------------------------------
+// View toolbar (sort / group / density controls)
+// ---------------------------------------------------------------------------
+
+function ViewToolbar(props: {
+  sortBy: SortBy
+  groupBy: GroupBy
+  density: Density
+  onSortChange: (s: SortBy) => void
+  onGroupChange: (g: GroupBy) => void
+  onDensityChange: (d: Density) => void
+}) {
+  const chipClass = (active: boolean) =>
+    active
+      ? "bg-fill-element-active text-text-strong"
+      : "text-text-weak hover:text-text-secondary-base hover:bg-fill-element-base"
+
   return (
-    <div class="flex items-center gap-3 my-2">
-      <hr class="flex-1 border-t border-border-base" />
-      <span class="text-11-regular text-text-weak shrink-0">{props.label}</span>
-      <hr class="flex-1 border-t border-border-base" />
+    <div class="flex flex-wrap items-center gap-x-4 gap-y-2 mb-4">
+      {/* Sort controls */}
+      <div class="flex items-center gap-1">
+        <span class="text-11-regular text-text-weak mr-1">Sort:</span>
+        <For each={[
+          ["activity", "Activity"],
+          ["repo", "Repo"],
+          ["created", "Created"],
+        ] as [SortBy, string][]}>
+          {([value, label]) => (
+            <button
+              type="button"
+              class="px-2 py-0.5 rounded text-11-regular transition-colors cursor-pointer"
+              classList={{ [chipClass(props.sortBy === value)]: true }}
+              onClick={() => props.onSortChange(value)}
+            >
+              {label}
+            </button>
+          )}
+        </For>
+      </div>
+
+      {/* Group controls */}
+      <div class="flex items-center gap-1">
+        <span class="text-11-regular text-text-weak mr-1">Group:</span>
+        <For each={[
+          ["time", "Time"],
+          ["repo", "Repo"],
+          ["status", "Status"],
+          ["none", "None"],
+        ] as [GroupBy, string][]}>
+          {([value, label]) => (
+            <button
+              type="button"
+              class="px-2 py-0.5 rounded text-11-regular transition-colors cursor-pointer"
+              classList={{ [chipClass(props.groupBy === value)]: true }}
+              onClick={() => props.onGroupChange(value)}
+            >
+              {label}
+            </button>
+          )}
+        </For>
+      </div>
+
+      {/* Density toggle */}
+      <div class="flex items-center gap-1 ml-auto">
+        <button
+          type="button"
+          class="px-1.5 py-0.5 rounded text-11-regular transition-colors cursor-pointer"
+          classList={{ [chipClass(props.density === "comfortable")]: true }}
+          onClick={() => props.onDensityChange("comfortable")}
+          title="Comfortable view"
+          aria-label="Comfortable density"
+        >
+          {"\u2630"}
+        </button>
+        <button
+          type="button"
+          class="px-1.5 py-0.5 rounded text-11-regular transition-colors cursor-pointer"
+          classList={{ [chipClass(props.density === "compact")]: true }}
+          onClick={() => props.onDensityChange("compact")}
+          title="Compact view"
+          aria-label="Compact density"
+        >
+          {"\u229E"}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Compact pod card (single-line density)
+// ---------------------------------------------------------------------------
+
+function CompactPodCard(props: {
+  pod: PodInfo
+  focused: boolean
+  onFocus: () => void
+  hideRepo?: boolean
+}) {
+  const ctx = useDevaipod()
+
+  const shortName = () => props.pod.Name.replace("devaipod-", "")
+  const isRunning = () => (props.pod.Status ?? "").toLowerCase() === "running"
+  const labels = () => props.pod.Labels ?? {}
+  const repo = () => labels()["io.devaipod.repo"] ?? ""
+  const agentStatus = () => ctx.agentStatus[props.pod.Name]
+  const title = () => agentStatus()?.title || labels()["io.devaipod.title"] || shortName()
+  const isDone = () => agentStatus()?.completion_status === "done"
+
+  const statusDot = createMemo(() => {
+    if (!isRunning()) return { char: "\u25CC", cls: "text-text-weak" }
+    if (isDone()) return { char: "\u25C6", cls: "text-violet-400" }
+    const activity = agentStatus()?.activity
+    if (activity === "Working") return { char: "\u25CF", cls: "text-icon-success-base" }
+    if (activity === "Idle") return { char: "\u25CB", cls: "text-icon-info-base" }
+    return { char: "\u2026", cls: "text-text-weak" }
+  })
+
+  const activityText = createMemo(() => {
+    if (!isRunning()) return ""
+    const s = agentStatus()
+    if (!s) return ""
+    if (s.current_tool) return `\u2192 ${s.current_tool}`
+    if (s.status_line) return s.status_line
+    return ""
+  })
+
+  const relativeTime = createMemo(() => {
+    const ts = effectiveTimestamp(props.pod)
+    if (!ts) return ""
+    const diff = Date.now() - ts
+    if (diff < 0 || diff < 60_000) return "just now"
+    if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
+    if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
+    return `${Math.floor(diff / 86_400_000)}d ago`
+  })
+
+  const repoShort = createMemo(() => {
+    const r = repo()
+    if (!r) return ""
+    const parts = r.split("/")
+    return parts[parts.length - 1]
+  })
+
+  let rowRef: HTMLDivElement | undefined
+
+  createEffect(() => {
+    if (props.focused && rowRef) {
+      rowRef.focus({ preventScroll: true })
+    }
+  })
+
+  return (
+    <div
+      ref={rowRef}
+      tabIndex={0}
+      onFocus={props.onFocus}
+      class="flex items-center gap-2 px-3 py-2 rounded border border-border-base bg-background-base transition-colors cursor-pointer hover:bg-fill-element-base"
+      classList={{
+        "ring-2 ring-border-active-base": props.focused,
+        "opacity-50": !isRunning() && !isDone(),
+        "opacity-70": isDone(),
+      }}
+      onClick={() => {
+        if (isRunning()) {
+          ctx.openPod(props.pod.Name).catch(alertError)
+        } else {
+          ctx.startPod(props.pod.Name).catch(alertError)
+        }
+      }}
+    >
+      <span class="text-14-medium shrink-0" classList={{ [statusDot().cls]: true }}>
+        {statusDot().char}
+      </span>
+
+      <span class="text-12-regular text-text-strong truncate min-w-0 flex-1" title={title()}>
+        {title()}
+      </span>
+
+      <Show when={!props.hideRepo && repoShort()}>
+        <span class="text-10-regular text-text-weak bg-fill-element-base px-1.5 py-0.5 rounded shrink-0 max-w-[120px] truncate">
+          {repoShort()}
+        </span>
+      </Show>
+
+      <Show when={activityText()}>
+        <span class="text-11-regular text-text-weak truncate max-w-[160px] shrink-0">
+          {activityText()}
+        </span>
+      </Show>
+
+      <span class="text-11-regular text-text-weak shrink-0">
+        {relativeTime()}
+      </span>
+
+      <Button
+        variant={isRunning() ? "primary" : "secondary"}
+        size="small"
+        onClick={(e: MouseEvent) => {
+          e.stopPropagation()
+          if (isRunning()) {
+            ctx.openPod(props.pod.Name).catch(alertError)
+          } else {
+            ctx.startPod(props.pod.Name).catch(alertError)
+          }
+        }}
+      >
+        {isRunning() ? "Open" : "Start"}
+      </Button>
     </div>
   )
 }
@@ -159,6 +396,14 @@ function PodsPageContent() {
   const [focusedIdx, setFocusedIdx] = createSignal(-1)
   const [searchText, setSearchText] = createSignal("")
 
+  // View preference state (createStore per project convention)
+  const [viewPrefs, setViewPrefs] = createStore<ViewPrefs>(loadViewPrefs())
+
+  // Persist preference changes
+  createEffect(() => {
+    saveViewPrefs({ sortBy: viewPrefs.sortBy, groupBy: viewPrefs.groupBy, density: viewPrefs.density })
+  })
+
   // Derive completion status for a pod from agent status
   const podCompletionStatus = (podName: string) =>
     ctx.agentStatus[podName]?.completion_status ?? "active"
@@ -169,48 +414,35 @@ function PodsPageContent() {
   const isPodDone = (podName: string) =>
     podCompletionStatus(podName) === "done"
 
-  // Frecency-sorted, then filtered pods
+  // Sorted, then filtered pods
   const filteredPods = createMemo(() => {
-    const sorted = frecencySortPods(ctx.pods)
+    const sorted = sortPods(ctx.pods, viewPrefs.sortBy)
     const raw = searchText().trim()
     if (!raw) return sorted
-
     const query = parseSearchQuery(raw)
     return sorted.filter((p) =>
       podMatchesQuery(p, query, isPodDone(p.Name), isPodRunning(p), ctx.agentStatus[p.Name]?.title)
     )
   })
 
-  // Group filtered pods into time sections
-  const sectionedPods = createMemo(() => {
-    const pods = filteredPods()
-    const now = Date.now()
-    const sections: { section: TimeSection; pods: PodInfo[] }[] = []
-    const buckets = new Map<TimeSection, PodInfo[]>()
-
-    for (const pod of pods) {
-      const ts = effectiveTimestamp(pod)
-      const sec = timeSection(ts, now)
-      let list = buckets.get(sec)
-      if (!list) {
-        list = []
-        buckets.set(sec, list)
-      }
-      list.push(pod)
-    }
-
-    for (const sec of TIME_SECTION_ORDER) {
-      const list = buckets.get(sec)
-      if (list && list.length > 0) {
-        sections.push({ section: sec, pods: list })
-      }
-    }
-
-    return sections
+  // Group filtered pods into labeled sections
+  const groupedPods = createMemo(() => {
+    return groupPods(
+      filteredPods(),
+      viewPrefs.groupBy,
+      (name) => ctx.agentStatus[name],
+    )
   })
 
-  // Whether to show section dividers (only if more than one section)
-  const showDividers = createMemo(() => sectionedPods().length > 1)
+  // Show dividers when there are multiple groups. For non-time groupings,
+  // also show a divider for a single named group (e.g., one "Working" section).
+  // For time grouping, match the original behavior: dividers only with 2+ sections.
+  const showDividers = createMemo(() => {
+    const groups = groupedPods()
+    if (groups.length > 1) return true
+    if (groups.length === 1 && groups[0].label !== "" && viewPrefs.groupBy !== "time") return true
+    return false
+  })
 
   // Filter counts for the filter chips
   const filterCounts = createMemo(() => {
@@ -306,13 +538,13 @@ function PodsPageContent() {
     return query.status ?? "all"
   })
 
-  // Compute a flat index offset for each section so we can map
-  // section-local indexes to the flat focused index
+  // Compute a flat index offset for each group so we can map
+  // group-local indexes to the flat focused index
   function flatIndexOffset(sectionIdx: number): number {
     let offset = 0
-    const sections = sectionedPods()
+    const groups = groupedPods()
     for (let i = 0; i < sectionIdx; i++) {
-      offset += sections[i].pods.length
+      offset += groups[i].pods.length
     }
     return offset
   }
@@ -399,6 +631,18 @@ function PodsPageContent() {
         </div>
       </Show>
 
+      {/* View toolbar */}
+      <Show when={ctx.pods.length > 0}>
+        <ViewToolbar
+          sortBy={viewPrefs.sortBy}
+          groupBy={viewPrefs.groupBy}
+          density={viewPrefs.density}
+          onSortChange={(s) => setViewPrefs("sortBy", s)}
+          onGroupChange={(g) => setViewPrefs("groupBy", g)}
+          onDensityChange={(d) => setViewPrefs("density", d)}
+        />
+      </Show>
+
       {/* Advisor placeholder when no advisor pod exists */}
       <Show when={!ctx.hasAdvisor()}>
         <AdvisorPlaceholder />
@@ -435,21 +679,42 @@ function PodsPageContent() {
           }
         >
           <div class="flex flex-col gap-3">
-            <For each={sectionedPods()}>
-              {(section, sectionIdx) => {
-                const offset = () => flatIndexOffset(sectionIdx())
+            <For each={groupedPods()}>
+              {(group, groupIdx) => {
+                const offset = () => flatIndexOffset(groupIdx())
                 return (
                   <>
-                    <Show when={showDividers()}>
-                      <SectionDivider label={section.section} />
+                    <Show when={showDividers() && group.label}>
+                      <div class="flex items-center gap-3 my-2">
+                        <hr class="flex-1 border-t border-border-base" />
+                        <span class="text-11-regular text-text-weak shrink-0">
+                          {group.label}
+                          <Show when={group.pods.length > 1}>
+                            <span class="ml-1 opacity-60">({group.pods.length})</span>
+                          </Show>
+                        </span>
+                        <hr class="flex-1 border-t border-border-base" />
+                      </div>
                     </Show>
-                    <For each={section.pods}>
+                    <For each={group.pods}>
                       {(pod, podIdx) => (
-                        <PodCard
-                          pod={pod}
-                          focused={focusedIdx() === offset() + podIdx()}
-                          onFocus={() => setFocusedIdx(offset() + podIdx())}
-                        />
+                        <Show
+                          when={viewPrefs.density === "compact"}
+                          fallback={
+                            <PodCard
+                              pod={pod}
+                              focused={focusedIdx() === offset() + podIdx()}
+                              onFocus={() => setFocusedIdx(offset() + podIdx())}
+                            />
+                          }
+                        >
+                          <CompactPodCard
+                            pod={pod}
+                            focused={focusedIdx() === offset() + podIdx()}
+                            onFocus={() => setFocusedIdx(offset() + podIdx())}
+                            hideRepo={viewPrefs.groupBy === "repo"}
+                          />
+                        </Show>
                       )}
                     </For>
                   </>
@@ -468,6 +733,19 @@ function PodsPageContent() {
 // Launch form
 // ---------------------------------------------------------------------------
 
+/** Generate a short title from task text by taking the first ~50 chars at a word boundary. */
+function autoTitleFromTask(task: string): string {
+  const trimmed = task.trim().replace(/\s+/g, " ")
+  if (!trimmed) return ""
+  // Take the first sentence or line, whichever is shorter
+  const firstLine = trimmed.split(/[.\n]/)[0].trim()
+  if (firstLine.length <= 50) return firstLine
+  // Truncate at word boundary
+  const cut = firstLine.slice(0, 50)
+  const lastSpace = cut.lastIndexOf(" ")
+  return lastSpace > 20 ? cut.slice(0, lastSpace) : cut
+}
+
 function LaunchForm(props: { onClose: () => void }) {
   const ctx = useDevaipod()
 
@@ -481,6 +759,7 @@ function LaunchForm(props: { onClose: () => void }) {
   const [devcontainerJson, setDevcontainerJson] = createSignal("")
   const [useDefaultDevcontainer, setUseDefaultDevcontainer] = createSignal(false)
   const [autoApprove, setAutoApprove] = createSignal(true)
+  const [autoTitle, setAutoTitle] = createSignal(true)
   const [submitting, setSubmitting] = createSignal(false)
   const [error, setError] = createSignal("")
 
@@ -525,6 +804,12 @@ function LaunchForm(props: { onClose: () => void }) {
       if (useDefaultDevcontainer()) params.use_default_devcontainer = true
       if (!autoApprove()) params.no_auto_approve = true
 
+      // Auto-generate title from task text if enabled
+      if (autoTitle() && t) {
+        const generated = autoTitleFromTask(t)
+        if (generated) params.title = generated
+      }
+
       await ctx.launchWorkspace(params)
       props.onClose()
     } catch (err) {
@@ -553,6 +838,18 @@ function LaunchForm(props: { onClose: () => void }) {
             onChange={setTask}
             multiline
           />
+
+          <Checkbox
+            checked={autoTitle()}
+            onChange={setAutoTitle}
+          >
+            Auto-generate title from task
+            <Show when={autoTitle() && task().trim()}>
+              <span class="ml-2 text-text-weak opacity-70">
+                — "{autoTitleFromTask(task())}"
+              </span>
+            </Show>
+          </Checkbox>
 
           <Collapsible variant="ghost">
             <Collapsible.Trigger class="flex items-center gap-2 text-12-regular text-text-weak cursor-pointer">

--- a/src/main.rs
+++ b/src/main.rs
@@ -807,6 +807,9 @@ enum HostCommand {
         /// interactive approval for tool usage.
         #[arg(long)]
         no_auto_approve: bool,
+        /// Human-readable title for this session (e.g. "refactoring auth")
+        #[arg(long, value_name = "TITLE")]
+        title: Option<String>,
     },
     /// Generate shell completions
     ///
@@ -1402,6 +1405,7 @@ async fn run_host(cli: HostCli) -> Result<()> {
             devcontainer_json,
             use_default_devcontainer,
             no_auto_approve,
+            title,
         } => {
             let source = resolve_source(source.as_deref(), &config)?;
 
@@ -1478,6 +1482,7 @@ async fn run_host(cli: HostCli) -> Result<()> {
                 devcontainer_json.as_deref(),
                 use_default_devcontainer,
                 !no_auto_approve,
+                title.as_deref(),
             )
             .await?;
 
@@ -2594,11 +2599,12 @@ async fn cmd_run(
     devcontainer_json: Option<&str>,
     use_default_devcontainer: bool,
     auto_approve: bool,
+    title: Option<&str>,
 ) -> Result<String> {
     // Build CreateOptions with mode=Run
     let create_opts = CreateOptions {
         task: command.map(|s| s.to_string()),
-        title: None,
+        title: title.map(|s| s.to_string()),
         image: image.map(|s| s.to_string()),
         name: explicit_name.map(|s| s.to_string()),
         service_gator_scopes: service_gator_scopes.to_vec(),
@@ -3571,6 +3577,7 @@ async fn create_advisor_pod(config: &config::Config, task: Option<&str>) -> Resu
         None,  // no devcontainer override
         false, // don't override project devcontainer
         true,  // auto_approve
+        None,  // no title for advisor
     )
     .await?;
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -1461,6 +1461,8 @@ struct RunRequest {
     /// Disable auto-approve of tool permissions
     #[serde(default)]
     no_auto_approve: bool,
+    /// Human-readable title for the workspace session
+    title: Option<String>,
 }
 
 /// Response for run endpoint
@@ -1562,6 +1564,10 @@ async fn run_workspace(
 
     if req.no_auto_approve {
         cmd.arg("--no-auto-approve");
+    }
+
+    if let Some(ref title) = req.title {
+        cmd.args(["--title", title]);
     }
 
     // Prevent stdin reads from blocking the server process
@@ -3971,5 +3977,21 @@ mod tests {
         let json = r#"{"devaipod-x":{"last_active_ts":42,"unknown_field":"ok"}}"#;
         let map: HashMap<String, CachedPodState> = serde_json::from_str(json).unwrap();
         assert_eq!(map["devaipod-x"].last_active_ts, Some(42));
+    }
+
+    #[test]
+    fn test_run_request_deserializes_title() {
+        let json = r#"{"source":"https://github.com/org/repo","task":"fix bug","title":"Fix the login bug"}"#;
+        let req: RunRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.title.as_deref(), Some("Fix the login bug"));
+        assert_eq!(req.source.as_deref(), Some("https://github.com/org/repo"));
+        assert_eq!(req.task.as_deref(), Some("fix bug"));
+    }
+
+    #[test]
+    fn test_run_request_title_is_optional() {
+        let json = r#"{"source":"https://github.com/org/repo"}"#;
+        let req: RunRequest = serde_json::from_str(json).unwrap();
+        assert!(req.title.is_none());
     }
 }


### PR DESCRIPTION
With many workspaces the pods page becomes hard to scan — too much
scrolling, no logical grouping, and workspaces are hard to tell apart
without reading the full task text.

This adds opt-in sort (activity/repo/created), group
(time/repo/status/none), and density (comfortable/compact) controls
to the pods page. The default view is unchanged. The "status" grouping
surfaces a "Needs Attention" category for idle workspaces that may
need user input. Preferences persist in localStorage.

The launch form now auto-generates a short title from the task text
so workspaces are identifiable at a glance without manual naming.
This required plumbing `--title` through to the `run` CLI subcommand,
which was already supported by `up`.